### PR TITLE
feat: global 초기 설정 구현(Swagger, API 공통 응답, 커스텀 예외처리, 헬스체크)

### DIFF
--- a/src/main/java/ject/petfit/global/common/ApiResponse.java
+++ b/src/main/java/ject/petfit/global/common/ApiResponse.java
@@ -1,0 +1,42 @@
+package ject.petfit.global.common;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ApiResponse<T> {
+    private final boolean success;
+    private final int code;
+    private final String message;
+    private final T data;
+
+    // 성공 응답 생성 메서드
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code(200)
+                .message("Success")
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code(200)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    // 실패 응답 생성 메서드
+    public static <T> ApiResponse<T> fail(int code, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(code)
+                .message(message)
+                .data(null)
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/global/config/SwaggerConfig.java
+++ b/src/main/java/ject/petfit/global/config/SwaggerConfig.java
@@ -1,0 +1,47 @@
+package ject.petfit.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "펫핏 API 명세서",
+                version = "v1",
+                description = "펫핏 API 명세서입니다"
+        ),
+        servers = {
+//                @Server(url = "배포할 도메인", description = "운영 서버"),
+                @Server(url = "http://localhost:8080", description = "로컬 서버")
+        }
+)
+@Configuration
+@Slf4j
+public class SwaggerConfig {
+    public static final String JWT_SECURITY_SCHEME = "JWT Token";
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .scheme("bearer")
+                .bearerFormat("JWT");
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+    }
+}
+
+

--- a/src/main/java/ject/petfit/global/dev/DevController.java
+++ b/src/main/java/ject/petfit/global/dev/DevController.java
@@ -1,0 +1,43 @@
+package ject.petfit.global.dev;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ject.petfit.global.common.ApiResponse;
+import ject.petfit.global.exception.CustomException;
+import ject.petfit.global.exception.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "개발용 테스트 API")
+@RequestMapping("/dev")
+public class DevController {
+
+    @Operation(summary = "스웨거 동작 확인",
+            description = "상세 설명")
+    @GetMapping()
+    public ResponseEntity<String> swaggerTest() {
+        return ResponseEntity.ok("Swagger Test");
+    }
+
+    @Operation(summary = "ApiResponse 확인용 예제",
+            description = "ApiResponse 적용 후 성공/실패, 예외처리 응답 형태 확인")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<String>> getUserName(@PathVariable Long id) {
+        if (id > 0) {
+            // 성공 응답
+            return ResponseEntity
+                    .ok(ApiResponse.success("김철수"));
+        }else if(id == 0){
+            // 실패 응답
+            return ResponseEntity
+                    .status(404)
+                    .body(ApiResponse.fail(404, "사용자를 찾을 수 없습니다(직접 기재)"));
+        }
+        // 예외처리 응답
+        throw new CustomException(ErrorCode.DEV_NOT_FOUND);
+    }
+}

--- a/src/main/java/ject/petfit/global/exception/CustomException.java
+++ b/src/main/java/ject/petfit/global/exception/CustomException.java
@@ -1,0 +1,16 @@
+package ject.petfit.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.httpStatus = errorCode.getHttpStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/ject/petfit/global/exception/ErrorCode.java
+++ b/src/main/java/ject/petfit/global/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package ject.petfit.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 커스텀 처리할 오류
+    DEV_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다(커스텀 예외 처리)");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/ject/petfit/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ject/petfit/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package ject.petfit.global.exception;
+
+import ject.petfit.global.common.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리 핸들러
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 커스텀할 예외 처리 핸들러
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        ApiResponse<Void> response = ApiResponse.fail(
+                e.getHttpStatus().value(),
+                e.getMessage()
+        );
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+
+    // 그외 모든 예외 처리 핸들러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        ApiResponse<Void> response = ApiResponse.fail(
+                500,
+                "서버 내부 오류가 발생하였습니다."
+        );
+        return ResponseEntity.status(500).body(response);
+    }
+}

--- a/src/main/java/ject/petfit/global/health/HealthCheckController.java
+++ b/src/main/java/ject/petfit/global/health/HealthCheckController.java
@@ -1,0 +1,15 @@
+package ject.petfit.global.health;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden // swagger에 노출 안되도록
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public String healthCheck() {
+        return "Success Health Check";
+    }
+}


### PR DESCRIPTION
### 📖 개요
global 초기 설정 구현(Swagger, API 공통 응답, 커스텀 예외처리, 헬스체크)

--------------

### ⚒️ 작업 내용
SwaggerConfig - 로컬서버만 할당, Bearer 토큰 넣어 요청 포함
ApiResponse - 프론트와 협업을 위한 API 공통 응답 설정 (응답성공여부, 상태코드, 메세지, 응답데이터)
exception 패키지 - 커스텀 예외처리 초기 세팅
HealthCheckController - 서버 상태 확인용으로 사용할 헬스체크 컨트롤러
DevController - 개발 테스트 용도 컨트롤러. 현재 스웨거 동작 확인과 API 공통 응답 확인 코드 작성해놓음

---------------

### 📕 관련 이슈
 - closed #2
 
---------------

### 특이사항
작성해놓은 api 요청이나 스웨거 동작 확인하려면, 현재 상황에선 gradle에서 security나 oauth2을 꺼놔야함
시큐리티는 인증을 요구하는게 기본 옵션이기때문 -> 해제하려면 필터체인에서 비활성화 옵션 작성해야함 