### PR TITLE
Feat/routine

### DIFF
--- a/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
+++ b/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
@@ -1,13 +1,58 @@
 package ject.petfit.domain.entry.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ject.petfit.domain.entry.dto.EntryDailyResponse;
+import ject.petfit.domain.entry.dto.EntryExistsResponse;
+import ject.petfit.domain.entry.service.EntryService;
+import ject.petfit.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/entries")
+@Tag(name = "Entry", description = "달력에서 기록 조회 API")
 public class EntryController {
-    // 월간 루틴체크,메모,특이사항 유무 조회
+    private final EntryService entryService;
 
-    // 주간 루틴, 특이사항 조회 (일간 포함 응답)
+    // 월간 루틴체크,메모,특이사항,(일정) 유무 조회
+    @GetMapping("/{petId}/monthly/{month}")
+    @Operation(summary = "월간 루틴체크, 메모, 특이사항, (일정) 유무 조회",
+            description = "특정 월의 루틴 체크, 메모, 특이사항, (일정) 유무를 조회 <br> " +
+                    "{month}는 yyyy-MM 형식으로 입력 <br> " +
+                    "요구사항은 아니지만 일정 유무도 응답에 포함함 ")
+    public ResponseEntity<ApiResponse<List<EntryExistsResponse>>> getMonthlyEntries(
+            @PathVariable Long petId,
+            @PathVariable String month
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(entryService.getMonthlyEntries(petId, month))
+        );
+    }
+
+    // 주간 루틴, 특이사항 조회
+    @GetMapping("/{petId}/weekly/{week}")
+    @Operation(summary = "주간 루틴, 특이사항 조회",
+            description = "특정 주의 루틴 체크, 메모, 특이사항을 조회 <br> " +
+                    "{week}는 주간의 시작 날짜를 yyyy-MM-dd 형식으로 입력 <br> " +
+                    "해당 주의 루틴 체크, 메모, 특이사항을 모두 조회 <br> " +
+                    "월간 조회처럼 유무 값도 포함 <br>" +
+                    "주간 조회 응답에서 일간 조회 뽑아서 사용하면 API 요청을 줄일 수 있으니 일간 조회API를 따로 만들지 않았음")
+    public ResponseEntity<ApiResponse<List<EntryDailyResponse>>> getWeeklyEntries(
+            @PathVariable Long petId,
+            @PathVariable String week
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(entryService.getWeeklyEntries(petId, week))
+        );
+    }
+
 }
 

--- a/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
+++ b/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
@@ -45,7 +45,7 @@ public class EntryController {
                     "해당 주의 루틴 체크, 메모, 특이사항을 모두 조회 <br> " +
                     "월간 조회처럼 유무 값도 포함 <br>" +
                     "주간 조회 응답에서 일간 조회 뽑아서 사용하면 API 요청을 줄일 수 있으니 일간 조회API를 따로 만들지 않았음")
-    public ResponseEntity<ApiResponse<List<EntryDailyResponse>>> getWeeklyEntries(
+    public ResponseEntity<ApiResponse<List<EntryDailyResponse>>> getWeeklyEntries(  //
             @PathVariable Long petId,
             @PathVariable String week
     ) {

--- a/src/main/java/ject/petfit/domain/entry/dto/EntryDailyResponse.java
+++ b/src/main/java/ject/petfit/domain/entry/dto/EntryDailyResponse.java
@@ -1,0 +1,53 @@
+package ject.petfit.domain.entry.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ject.petfit.domain.remark.dto.response.RemarkResponse;
+import ject.petfit.domain.routine.dto.response.RoutineResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ject.petfit.domain.entry.entity.Entry;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "달력에서 기록 주간 응답 DTO")
+public class EntryDailyResponse {
+    @Schema(description = "날짜", example = "2025-07-01")
+    private String entryDate; // 날짜
+
+    @Schema(description = "루틴체크 존재 여부", example = "true")
+    private boolean isChecked; // 루틴체크 존재 여부
+
+    @Schema(description = "메모 존재 여부", example = "true")
+    private boolean isMemo; // 메모 존재 여부
+
+    @Schema(description = "특이사항 존재 여부", example = "true")
+    private boolean isRemarked; // 특이사항 존재 여부
+
+    @Schema(description = "일정 존재 여부", example = "false")
+    private boolean isScheduled; // 일정 존재 여부
+
+    List<RoutineResponse> routineResponseList;
+    List<RemarkResponse> remarkResponseList;
+
+    public static EntryDailyResponse from(Entry entry) {
+        return EntryDailyResponse.builder()
+                .entryDate(entry.getEntryDate().toString())
+                .isChecked(entry.getIsChecked())
+                .isMemo(entry.getIsMemo())
+                .isRemarked(entry.getIsRemarked())
+                .isScheduled(entry.getIsScheduled())
+                .routineResponseList(entry.getRoutines().stream()
+                        .map(RoutineResponse::from)
+                        .toList())
+                .remarkResponseList(entry.getRemarks().stream()
+                        .map(RemarkResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/entry/dto/EntryDetailResponse.java
+++ b/src/main/java/ject/petfit/domain/entry/dto/EntryDetailResponse.java
@@ -1,0 +1,28 @@
+package ject.petfit.domain.entry.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ject.petfit.domain.remark.dto.response.RemarkResponse;
+import ject.petfit.domain.remark.entity.Remark;
+import ject.petfit.domain.routine.dto.response.RoutineResponse;
+import ject.petfit.domain.routine.entity.Routine;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "하루 루틴, 특이사항 응답 DTO")
+public class EntryDetailResponse {
+    private RoutineResponse routineResponse; // 루틴 응답
+    private RemarkResponse remarkResponse; // 특이사항 응답
+
+    public static EntryDetailResponse of(Routine routine, Remark remark) {
+        return EntryDetailResponse.builder()
+                .routineResponse(RoutineResponse.from(routine))
+                .remarkResponse(RemarkResponse.from(remark))
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/entry/dto/EntryExistsResponse.java
+++ b/src/main/java/ject/petfit/domain/entry/dto/EntryExistsResponse.java
@@ -1,0 +1,40 @@
+package ject.petfit.domain.entry.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ject.petfit.domain.entry.entity.Entry;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "달력에서 기록 존재 여부 응답 DTO")
+public class EntryExistsResponse {
+    @Schema(description = "날짜", example = "2025-07-01")
+    private String entryDate; // 날짜
+
+    @Schema(description = "루틴체크 존재 여부", example = "true")
+    private boolean isChecked; // 루틴체크 존재 여부
+
+    @Schema(description = "메모 존재 여부", example = "true")
+    private boolean isMemo; // 메모 존재 여부
+
+    @Schema(description = "특이사항 존재 여부", example = "true")
+    private boolean isRemarked; // 특이사항 존재 여부
+
+    @Schema(description = "일정 존재 여부", example = "false")
+    private boolean isScheduled; // 일정 존재 여부
+
+    public static EntryExistsResponse from(Entry entry) {
+        return EntryExistsResponse.builder()
+                .entryDate(entry.getEntryDate().toString())
+                .isChecked(entry.getIsChecked())
+                .isMemo(entry.getIsMemo())
+                .isRemarked(entry.getIsRemarked())
+                .isScheduled(entry.getIsScheduled())
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/entry/entity/Entry.java
+++ b/src/main/java/ject/petfit/domain/entry/entity/Entry.java
@@ -5,6 +5,7 @@ import ject.petfit.domain.pet.entity.Pet;
 import ject.petfit.domain.remark.entity.Remark;
 import ject.petfit.domain.routine.entity.Routine;
 import ject.petfit.domain.schedule.entity.Schedule;
+import ject.petfit.global.common.BaseTime;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -19,7 +20,7 @@ import java.util.List;
 @Table(name = "entry", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"entry_date", "pet_id"})
 })
-public class Entry {
+public class Entry extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long entryId;
@@ -61,7 +62,6 @@ public class Entry {
     public void updateScheduledFalse() {
         this.isScheduled = false;
     }
-
     public void updateCheckedFalse() {
         this.isChecked = false;
     }

--- a/src/main/java/ject/petfit/domain/entry/exception/EntryErrorCode.java
+++ b/src/main/java/ject/petfit/domain/entry/exception/EntryErrorCode.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum EntryErrorCode {
-    ENTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "ENTRY-404", "일정을 찾을 수 없습니다."),
-    ENTRY_ALREADY_EXISTS(HttpStatus.CONFLICT, "ENTRY-409", "이미 존재하는 Entry입니다.");
+    ENTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "ENTRY-404", "기록을 찾을 수 없습니다."),
+    ENTRY_ALREADY_EXISTS(HttpStatus.CONFLICT, "ENTRY-409", "이미 존재하는 기록 입니다."),
+    INVALID_ENTRY_REQUEST(HttpStatus.BAD_REQUEST, "ENTRY-400", "유효하지 않은 기록 요청입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/ject/petfit/domain/entry/repository/EntryRepository.java
+++ b/src/main/java/ject/petfit/domain/entry/repository/EntryRepository.java
@@ -18,4 +18,6 @@ public interface EntryRepository extends JpaRepository<Entry, Long> {
 
     //isRemarked
     List<Entry> findAllByPetAndIsRemarkedTrueAndEntryDateBetween(Pet pet, LocalDate startDate, LocalDate endDate);
+
+    List<Entry> findAllByPetAndEntryDateBetween(Pet pet, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/ject/petfit/domain/entry/service/EntryService.java
+++ b/src/main/java/ject/petfit/domain/entry/service/EntryService.java
@@ -1,6 +1,8 @@
 package ject.petfit.domain.entry.service;
 
 import jakarta.transaction.Transactional;
+import ject.petfit.domain.entry.dto.EntryDailyResponse;
+import ject.petfit.domain.entry.dto.EntryExistsResponse;
 import ject.petfit.domain.entry.entity.Entry;
 import ject.petfit.domain.entry.exception.EntryErrorCode;
 import ject.petfit.domain.entry.exception.EntryException;
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +21,8 @@ public class EntryService {
     private final EntryRepository entryRepository;
     private final PetRepository petRepository;
 
-    // (펫ID & 날짜)의 entry가 있으면 반환, 없으면 생성해서 반환
+    // ----------------------------- 엔트리 공통 메서드 -----------------------------------
+    // (펫ID & 날짜)의 entry가 있으면 조회, 없으면 생성 - 다른 서비스에서 사용
     @Transactional
     public Entry getOrCreateEntry(Pet pet, LocalDate entryDate) {
         Entry entry;
@@ -48,12 +52,47 @@ public class EntryService {
 
     // Entry 존재 여부 확인 (펫, 조회 날짜) // 캐시 예정
     public Boolean isEntryExist(Pet pet, LocalDate entryDate) {
+        if (pet == null || entryDate == null) {
+            throw new EntryException(EntryErrorCode.INVALID_ENTRY_REQUEST);
+        }
         return entryRepository.existsByPetAndEntryDate(pet, entryDate);
     }
 
     // Entry 조회 (펫, 조회 날짜)
     public Entry getEntry(Pet pet, LocalDate targetDate) {
+        if (!isEntryExist(pet, targetDate)) {
+            throw new EntryException(EntryErrorCode.ENTRY_NOT_FOUND);
+        }
         return entryRepository.findByPetAndEntryDate(pet, targetDate);
+    }
+
+    // ------------------------------ API 메서드 -----------------------------------
+    // 월간 루틴체크, 메모, 특이사항, (일정) 유무 조회
+    public List<EntryExistsResponse> getMonthlyEntries(Long petId, String month) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new EntryException(EntryErrorCode.ENTRY_NOT_FOUND));
+
+        LocalDate startDate = LocalDate.parse(month + "-01");
+        LocalDate endDate = startDate.plusMonths(1).minusDays(1);
+
+        List<Entry> entries = entryRepository.findAllByPetAndEntryDateBetween(pet, startDate, endDate);
+
+        return entries.stream()
+                .map(EntryExistsResponse::from)
+                .toList();
+    }
+
+    // 주간 루틴, 특이사항 조회
+    public List<EntryDailyResponse> getWeeklyEntries(Long petId, String week) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new EntryException(EntryErrorCode.ENTRY_NOT_FOUND));
+        LocalDate startDate = LocalDate.parse(week);
+        LocalDate endDate = startDate.plusDays(6);
+        List<Entry> entries = entryRepository.findAllByPetAndEntryDateBetween(pet, startDate, endDate);
+
+        return entries.stream()
+                .map(EntryDailyResponse::from)
+                .toList();
     }
 }
 

--- a/src/main/java/ject/petfit/domain/pet/entity/Pet.java
+++ b/src/main/java/ject/petfit/domain/pet/entity/Pet.java
@@ -3,6 +3,7 @@ package ject.petfit.domain.pet.entity;
 import jakarta.persistence.*;
 import ject.petfit.domain.entry.entity.Entry;
 import ject.petfit.domain.member.entity.Member;
+import ject.petfit.domain.slot.entity.Slot;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,6 +43,9 @@ public class Pet {
 
     @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Entry> entries;
+
+    @OneToOne(mappedBy = "pet")
+    private Slot slot;
 
     @Builder
     public Pet(String name, String type, String gender, LocalDate birthDate, boolean isFirst) {

--- a/src/main/java/ject/petfit/domain/remark/controller/RemarkController.java
+++ b/src/main/java/ject/petfit/domain/remark/controller/RemarkController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Remark", description = "특이사항(메모) API")
+@Tag(name = "Remark", description = "특이사항 API")
 @RequestMapping("/api/remarks")
 public class RemarkController {
     private final ject.petfit.domain.remark.service.RemarkService remarkService;

--- a/src/main/java/ject/petfit/domain/remark/dto/request/RemarkRegisterRequest.java
+++ b/src/main/java/ject/petfit/domain/remark/dto/request/RemarkRegisterRequest.java
@@ -1,5 +1,6 @@
 package ject.petfit.domain.remark.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -15,13 +16,16 @@ import lombok.NoArgsConstructor;
 public class RemarkRegisterRequest {
     @NotNull(message = "제목은 필수입니다.")
     @Size(max = 20, message = "제목은 20자 이내여야 합니다.")
+    @Schema(description = "특이사항 제목", example = "댕댕이 구토")
     private String title;
 
     @Size(max = 200, message = "내용은 200자 이내여야 합니다.")
+    @Schema(description = "특이사항 내용", example = "댕댕이가 오늘 열이나고..")
     private String content;
 
     @NotNull(message = "날짜는 필수입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜는 YYYY-MM-DD 형식이어야 합니다.")
+    @Schema(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-07-01")
     private String remarkDate;
 }
 

--- a/src/main/java/ject/petfit/domain/remark/dto/response/RemarkResponse.java
+++ b/src/main/java/ject/petfit/domain/remark/dto/response/RemarkResponse.java
@@ -15,15 +15,12 @@ import lombok.NoArgsConstructor;
 public class RemarkResponse {
     @Schema(description = "특이사항 ID", example = "1")
     private Long scheduleId; // 일정 ID
-
-    @Schema(description = "특이사항 제목", example = "댕댕이 구토")
+    @Schema(description = "특이사항 제목", example = "구토")
     private String title; // 일정 제목
-
-    @Schema(description = "특이사항 내용", example = "댕댕이가 오늘 열이나고..")
+    @Schema(description = "특이사항 내용", example = "아침에 구토를 2회 했음")
     private String content; // 일정 내용
-
-    @Schema(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-07-01")
-    private String remarkDate; // 대상 날짜 (YYYY-MM-DD)
+    @Schema(description = "특이사항 날짜 (YYYY-MM-DD)", example = "2025-06-29")
+    private String remarkDate; // 특이사항 대상 날짜 (YYYY-MM-DD)
 
     public static RemarkResponse from(Remark remark) {
         return RemarkResponse.builder()

--- a/src/main/java/ject/petfit/domain/routine/controller/RoutineController.java
+++ b/src/main/java/ject/petfit/domain/routine/controller/RoutineController.java
@@ -1,10 +1,83 @@
 package ject.petfit.domain.routine.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import ject.petfit.domain.routine.dto.request.RoutineMemoRequest;
+import ject.petfit.domain.routine.dto.response.RoutineResponse;
+import ject.petfit.domain.routine.service.RoutineService;
+import ject.petfit.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/routines")
+@Tag(name = "Routine", description = "홈화면 오늘의 루틴 API")
 public class RoutineController {
-    // TODO: 구현
+    private final RoutineService routineService;
+
+    // 루틴 조회 - 일간
+    @GetMapping("/{petId}/daily/{date}")
+    @Operation(summary = "일간 루틴 조회", description = "특정 날짜의 일간 루틴들을 조회 <br> " +
+            "{date}는 yyyy-MM-dd 형식으로 입력 <br> " +
+            "체크나 세모 등록된 값들만 응답" )
+    public ResponseEntity<ApiResponse<List<RoutineResponse>>> getDailyRoutines(
+            @PathVariable Long petId,
+            @PathVariable String date
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(routineService.getDailyRoutines(petId, date))
+        );
+    }
+
+    // 루틴 체크(V) 완료
+    @PostMapping("/{petId}/{date}/{category}/check")
+    @Operation(summary = "루틴 체크 완료", description = "루틴을 체크 완료 상태로 변경 <br> " +
+            "{date}는 yyyy-MM-dd 형식으로 입력 <br>{category}는 루틴 종류 - feed, water, walk, potty, dental, skin")
+    public ResponseEntity<ApiResponse<String>> checkRoutine(
+            @PathVariable Long petId,
+            @PathVariable String date,
+            @PathVariable String category
+//            @RequestBody RoutineRequest routineRequest
+    ) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiResponse.success(routineService.checkRoutine(petId, date, category))
+        );
+    }
+
+    // 루틴 세모
+    @PostMapping("/{petId}/{date}/{category}/memo")
+    @Operation(summary = "루틴 메모(세모)", description = "루틴을 메모 상태로 작성 <br> " +
+            "{date}는 yyyy-MM-dd 형식으로 입력 <br>{category}는 루틴 종류 - feed, water, walk, potty, dental, skin <br> " +
+            "content가 산책, 사료, 음수일때는 내용 | 배변, 치아, 피부일때는 메모로 사용")
+    public ResponseEntity<ApiResponse<RoutineResponse>> createRoutineMemo(
+            @PathVariable Long petId,
+            @PathVariable String date,
+            @PathVariable String category,
+            @Valid @RequestBody RoutineMemoRequest routineMemoRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiResponse.success(routineService.createRoutineMemo(petId, date, category, routineMemoRequest))
+        );
+    }
+
+    // 루틴 해제
+    @DeleteMapping("/{petId}/{date}/{category}/uncheck")
+    @Operation(summary = "루틴 해제", description = "루틴을 해제(DB 삭제) <br> " +
+            "{date}는 yyyy-MM-dd 형식으로 입력 <br>{category}는 루틴 종류 - feed, water, walk, potty, dental, skin")
+    public ResponseEntity<ApiResponse<String>> uncheckRoutine(
+            @PathVariable Long petId,
+            @PathVariable String date,
+            @PathVariable String category
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(routineService.uncheckRoutine(petId, date, category))
+        );
+    }
 }

--- a/src/main/java/ject/petfit/domain/routine/dto/request/RoutineMemoRequest.java
+++ b/src/main/java/ject/petfit/domain/routine/dto/request/RoutineMemoRequest.java
@@ -1,0 +1,22 @@
+package ject.petfit.domain.routine.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class RoutineMemoRequest {
+    @Min(value = 0, message = "분량은 0 이상이어야 합니다.")
+    @Max(value = 99999, message = "분량은 5자리 이하여야 합니다.")
+    @Schema(description = "실제량 (사료, 음수, 산책에만 응답)", example = "0")
+    private Integer actualAmount;   // 실제량 (사료, 음수, 산책에만 응답)
+
+    @Size(max = 200, message = "내용은 200자 이내여야 합니다.")
+    @Schema(description = "내용 or 메모", example = "비와서 산책 안 감")
+    private String content;         // 내용 or 메모
+}

--- a/src/main/java/ject/petfit/domain/routine/dto/response/RoutineResponse.java
+++ b/src/main/java/ject/petfit/domain/routine/dto/response/RoutineResponse.java
@@ -1,0 +1,42 @@
+package ject.petfit.domain.routine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ject.petfit.domain.routine.entity.Routine;
+import ject.petfit.domain.routine.enums.RoutineStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "루틴 응답 DTO")
+public class RoutineResponse {
+    @Schema(description = "루틴 ID", example = "1")
+    private Long routineId; // 루틴 ID
+    @Schema(description = "루틴 카테고리", example = "feed")
+    private String category; // 루틴 카테고리
+    @Schema(description = "루틴 상태 (체크 완료, 세모 등)", example = "CHECKED")
+    private RoutineStatus status; // 루틴 상태 (체크 완료, 세모 등)
+    @Schema(description = "목표량", example = "150")
+    private Integer targetAmount; // 목표량
+    @Schema(description = "실제량", example = "150")
+    private Integer actualAmount; // 실제량
+
+    private String content; // 내용 or 메모
+    private String date; // 날짜 (YYYY-MM-DD)
+
+    public static RoutineResponse from(Routine routine) {
+        return RoutineResponse.builder()
+                .routineId(routine.getRoutineId())
+                .category(routine.getCategory())
+                .status(routine.getStatus())
+                .targetAmount(routine.getTargetAmount())
+                .actualAmount(routine.getActualAmount())
+                .content(routine.getContent())
+                .date(routine.getEntry().getEntryDate().toString())
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/routine/entity/Routine.java
+++ b/src/main/java/ject/petfit/domain/routine/entity/Routine.java
@@ -2,7 +2,11 @@ package ject.petfit.domain.routine.entity;
 
 import jakarta.persistence.*;
 import ject.petfit.domain.entry.entity.Entry;
+import ject.petfit.domain.routine.enums.RoutineStatus;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -11,20 +15,36 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @ToString
-public class Routine {
+public class Routine  {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long routineId;
 
     @Column(nullable = false)
-    private String category;
+    private String category;        // feed, water, walk | potty, dental, skin
 
-    private String status;          // 체크 선택, 체크 해제, 세모
+    @Enumerated(EnumType.STRING)
+    private RoutineStatus status;    // 체크 선택, 세모 (체크 해제는 엔티티 삭제)
     private Integer targetAmount;   // 목표량
     private Integer actualAmount;   // 실제량
     private String content;         // 내용 or 메모
 
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "entry_id")
     private Entry entry;
+
+    public void updateStatus(RoutineStatus status) {
+        this.status = status;
+    }
+
+    public void updateActualAmount(Integer actualAmount) {
+        this.actualAmount = actualAmount;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/ject/petfit/domain/routine/enums/RoutineStatus.java
+++ b/src/main/java/ject/petfit/domain/routine/enums/RoutineStatus.java
@@ -1,0 +1,8 @@
+package ject.petfit.domain.routine.enums;
+
+// ...existing code...
+public enum RoutineStatus {
+    CHECKED, MEMO
+}
+// ...existing code...
+

--- a/src/main/java/ject/petfit/domain/routine/exception/RoutineErrorCode.java
+++ b/src/main/java/ject/petfit/domain/routine/exception/RoutineErrorCode.java
@@ -1,0 +1,17 @@
+package ject.petfit.domain.routine.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RoutineErrorCode {
+    ROUTINE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTINE-404", "해당하는 루틴 카테고리를 찾을 수 없습니다."),
+    ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTINE-404", "해당하는 루틴을 찾을 수 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ject/petfit/domain/routine/exception/RoutineException.java
+++ b/src/main/java/ject/petfit/domain/routine/exception/RoutineException.java
@@ -1,0 +1,16 @@
+package ject.petfit.domain.routine.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class RoutineException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String code;
+
+    public RoutineException(RoutineErrorCode routineErrorCode) {
+        super(routineErrorCode.getMessage());
+        this.httpStatus = routineErrorCode.getHttpStatus();
+        this.code = routineErrorCode.getCode();
+    }
+}

--- a/src/main/java/ject/petfit/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/ject/petfit/domain/routine/repository/RoutineRepository.java
@@ -1,8 +1,21 @@
 package ject.petfit.domain.routine.repository;
 
+import ject.petfit.domain.entry.entity.Entry;
 import ject.petfit.domain.routine.entity.Routine;
+import ject.petfit.domain.routine.enums.RoutineStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoutineRepository extends JpaRepository<Routine, Long> {
-}
+import java.util.List;
+import java.util.Optional;
 
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    Optional<Routine> findByEntryAndCategory(Entry entry, String category);
+    boolean existsByEntryAndCategory(Entry entry, String category);
+
+    boolean existsByEntry(Entry entry);
+
+    boolean existsByEntryAndStatus(Entry entry, RoutineStatus status);
+
+    List<Routine> findAllByEntry(Entry entry);
+
+}

--- a/src/main/java/ject/petfit/domain/routine/service/RoutineService.java
+++ b/src/main/java/ject/petfit/domain/routine/service/RoutineService.java
@@ -1,10 +1,178 @@
 package ject.petfit.domain.routine.service;
 
+import jakarta.transaction.Transactional;
+import ject.petfit.domain.entry.entity.Entry;
+import ject.petfit.domain.entry.repository.EntryRepository;
+import ject.petfit.domain.entry.service.EntryService;
+import ject.petfit.domain.pet.entity.Pet;
+import ject.petfit.domain.pet.exception.PetErrorCode;
+import ject.petfit.domain.pet.exception.PetException;
+import ject.petfit.domain.pet.repository.PetRepository;
+import ject.petfit.domain.routine.dto.request.RoutineMemoRequest;
+import ject.petfit.domain.routine.dto.response.RoutineResponse;
+import ject.petfit.domain.routine.entity.Routine;
+import ject.petfit.domain.routine.enums.RoutineStatus;
+import ject.petfit.domain.routine.exception.RoutineErrorCode;
+import ject.petfit.domain.routine.exception.RoutineException;
+import ject.petfit.domain.routine.repository.RoutineRepository;
+import ject.petfit.domain.slot.entity.Slot;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RoutineService {
-    // TODO: 구현
+    private final RoutineRepository routineRepository;
+    private final PetRepository petRepository;
+    private final EntryService entryService;
+
+    // ------------------------------ 루틴 공통 메서드 -----------------------------------
+    // 카테고리에 따른 슬롯 목표량 or null 반환
+    public Integer getTargetAmountByCategory(Slot slot, String category) {
+        return switch (category) {
+            case "feed" -> slot.getFeedAmount();
+            case "water" -> slot.getWaterAmount();
+            case "walk" -> slot.getWalkAmount();
+            case "potty", "skin", "dental" -> null;
+            default -> throw new RoutineException(RoutineErrorCode.ROUTINE_CATEGORY_NOT_FOUND);
+        };
+    }
+
+    // 루틴 해제 후 체크 존재 여부로 entry 업데이트
+    public void updateEntryChecked(Entry entry) {
+        if (!routineRepository.existsByEntryAndStatus(entry, RoutineStatus.CHECKED)) {
+            entry.updateCheckedFalse();
+        }
+    }
+
+    // 루틴 해제 후 메모 존재 여부로 entry 업데이트
+    public void updateEntryMemo(Entry entry) {
+        if (!routineRepository.existsByEntryAndStatus(entry, RoutineStatus.MEMO)) {
+            entry.updateMemoFalse();
+        }
+    }
+
+    // ------------------------------ API 메서드 -----------------------------------
+
+    // 루틴 조회 - 일간
+    public List<RoutineResponse> getDailyRoutines(Long petId, String date) {
+
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
+
+        // 해당 날짜의 entry 조회
+        LocalDate entryDate = LocalDate.parse(date);
+        Entry entry = entryService.getEntry(pet, entryDate);
+
+        // 루틴 조회
+        List<Routine> routines = routineRepository.findAllByEntry(entry);
+
+        // 루틴 응답으로 변환
+        return routines.stream()
+                .map(RoutineResponse::from)
+                .toList();
+    }
+
+    // 루틴 체크(V) 완료
+    @Transactional
+    public String checkRoutine(Long petId, String date, String category) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
+
+        // 해당 날짜의 entry가 있으면 조회 없으면 생성
+        LocalDate entryDate = LocalDate.parse(date);
+        Entry entry = entryService.getOrCreateEntry(pet, entryDate);
+
+        // 카테고리 따라 목표량 달라짐
+        Integer targetAmount = getTargetAmountByCategory(pet.getSlot(), category);
+
+        // 루틴 조회해서 없으면 생성 있으면 수정(메모->체크 수정하는 케이스)
+        Routine routine = routineRepository.findByEntryAndCategory(entry, category)
+                .orElseGet(() -> {
+                    // 루틴이 없으면 새로 생성
+                    return Routine.builder()
+                            .entry(entry)
+                            .category(category)
+                            .targetAmount(targetAmount)
+                            .build();
+                });
+        // 루틴 체크로 설정
+        routine.updateStatus(RoutineStatus.CHECKED); // 상태를 체크로 변경
+        routine.updateActualAmount(targetAmount); // 실제량을 목표량으로 설정
+        routine.updateContent(null); // 내용은 null로 설정 (메모가 없으므로)
+
+        // 루틴 저장
+        routineRepository.save(routine);
+
+        // 기록 여부 업데이트
+        entry.updateCheckedTrue();
+
+        return "CHECKED";
+    }
+
+    // 루틴 세모
+    @Transactional
+    public RoutineResponse createRoutineMemo(Long petId, String date, String category, RoutineMemoRequest request) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
+
+        // 해당 날짜의 entry가 있으면 조회 없으면 생성
+        LocalDate entryDate = LocalDate.parse(date);
+        Entry entry = entryService.getOrCreateEntry(pet, entryDate);
+
+        // 카테고리 따라 목표량 달라짐
+        Integer targetAmount = getTargetAmountByCategory(pet.getSlot(), category);
+
+        // 루틴 조회해서 없으면 생성 있으면 수정(체크->메모 수정하는 케이스)
+        Routine routine = routineRepository.findByEntryAndCategory(entry, category)
+                .orElseGet(() -> {
+                    // 루틴이 없으면 새로 생성
+                    return Routine.builder()
+                            .entry(entry)
+                            .category(category)
+                            .targetAmount(targetAmount)
+                            .build();
+                });
+        // 루틴 메모로 설정
+        routine.updateStatus(RoutineStatus.MEMO); // 상태를 메모로 변경
+        routine.updateActualAmount(request.getActualAmount()); // 실제량은 요청에서 가져옴
+        routine.updateContent(request.getContent()); // 내용은 요청에서 가져옴
+
+        // 루틴 저장
+        routineRepository.save(routine);
+
+        // 기록 여부 업데이트
+        entry.updateMemoTrue();
+
+        return RoutineResponse.from(routine);
+    }
+
+    // 루틴 해제
+    @Transactional
+    public String uncheckRoutine(Long petId, String date, String category) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
+        // 해당 날짜의 entry가 없으면 예외 발생
+        LocalDate entryDate = LocalDate.parse(date);
+        Entry entry = entryService.getEntry(pet, entryDate);
+
+        // 루틴 조회
+        Routine routine = routineRepository.findByEntryAndCategory(entry, category)
+                .orElseThrow(() -> new RoutineException(RoutineErrorCode.ROUTINE_NOT_FOUND));
+
+        // 루틴 삭제
+        routineRepository.delete(routine);
+
+        // 기록 여부 업데이트
+        if (routine.getStatus() == RoutineStatus.CHECKED) {
+            updateEntryChecked(entry);
+        } else if (routine.getStatus() == RoutineStatus.MEMO) {
+            updateEntryMemo(entry);
+        }
+
+        return "UNCHECKED";
+    }
 }

--- a/src/main/java/ject/petfit/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/ject/petfit/domain/schedule/controller/ScheduleController.java
@@ -50,8 +50,9 @@ public class ScheduleController {
 
     // 일정 등록
     // 현재는 '일'까지만 요청, 추후 '시분초'까지 요청 가능하도록 변경할지 검토 필요
-    @PostMapping("/{petId}")
-    @Operation(summary = "일정 등록", description = "title(20자), content(200자), targetDate(YYYY-MM-DD) 형식 제한")
+    @PostMapping("/{petId}/{date}")
+    @Operation(summary = "일정 등록", description = "title(20자), content(200자), targetDate(yyyy-MM-dd) 형식 제한 <br> " +
+            "알림 기능 확장시 targetTime(시:분:초)도 추가 예정")
     public ResponseEntity<ApiResponse<ScheduleResponse>> createSchedule(
             @PathVariable Long petId,
             @RequestBody @Valid ScheduleRegisterRequest scheduleRegisterRequest) {

--- a/src/main/java/ject/petfit/domain/schedule/dto/request/ScheduleRegisterRequest.java
+++ b/src/main/java/ject/petfit/domain/schedule/dto/request/ScheduleRegisterRequest.java
@@ -1,5 +1,6 @@
 package ject.petfit.domain.schedule.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -15,12 +16,15 @@ import lombok.NoArgsConstructor;
 public class ScheduleRegisterRequest {
     @NotNull(message = "제목은 필수입니다.")
     @Size(max = 20, message = "제목은 20자 이내여야 합니다.")
+    @Schema(description = "일정 제목", example = "병원")
     private String title;        // 일정 제목
 
     @Size(max = 200, message = "내용은 200자 이내여야 합니다.")
+    @Schema(description = "일정 내용", example = "제일 조은 동물병원, 치석 제거")
     private String content;      // 일정 내용
 
     @NotNull(message = "날짜는 필수입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜는 YYYY-MM-DD 형식이어야 합니다.")
+    @Schema(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-07-01")
     private String targetDate;   // 대상 날짜(YYYY-MM-DD)
 }

--- a/src/main/java/ject/petfit/domain/schedule/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/ject/petfit/domain/schedule/dto/request/ScheduleUpdateRequest.java
@@ -1,5 +1,6 @@
 package ject.petfit.domain.schedule.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -14,8 +15,10 @@ import lombok.NoArgsConstructor;
 public class ScheduleUpdateRequest {
     @NotNull(message = "제목은 필수입니다.")
     @Size(max = 20, message = "제목은 20자 이내여야 합니다.")
+    @Schema(description = "일정 제목", example = "병원")
     private String title;        // 일정 제목
 
     @Size(max = 200, message = "내용은 200자 이내여야 합니다.")
+    @Schema(description = "일정 내용", example = "제일 조은 동물병원, 치석 제거")
     private String content;      // 일정 내용
 }

--- a/src/main/java/ject/petfit/domain/schedule/dto/response/ScheduleResponse.java
+++ b/src/main/java/ject/petfit/domain/schedule/dto/response/ScheduleResponse.java
@@ -13,16 +13,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(description = "일정 응답 DTO")
 public class ScheduleResponse {
-    @Schema(description = "일정 ID", example = "1")
     private Long scheduleId; // 일정 ID
-
-    @Schema(description = "일정 제목", example = "병원")
     private String title; // 일정 제목
-
-    @Schema(description = "일정 내용", example = "제일 조은 동물병원, 치석 제거")
     private String content; // 일정 내용
-
-    @Schema(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-07-01")
     private String targetDate; // 대상 날짜 (YYYY-MM-DD)
 
     public static ScheduleResponse from(Schedule schedule) {

--- a/src/main/java/ject/petfit/domain/schedule/entity/Schedule.java
+++ b/src/main/java/ject/petfit/domain/schedule/entity/Schedule.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import ject.petfit.domain.entry.entity.Entry;
 import ject.petfit.global.common.BaseTime;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;

--- a/src/main/java/ject/petfit/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/ject/petfit/domain/schedule/service/ScheduleService.java
@@ -79,9 +79,6 @@ public class ScheduleService {
         // (펫ID & 날짜)의 entry가 있으면 반환, 없으면 생성해서 반환
         Entry entry = entryService.getOrCreateEntry(pet, targetDate);
 
-        // 일정 등록여부 true로 변경
-        entry.updateScheduledTrue();
-
         // 일정 등록
         LocalDateTime targetDateTime = targetDate.atStartOfDay();
         Schedule schedule = scheduleRepository.save(
@@ -91,6 +88,10 @@ public class ScheduleService {
                         .content(request.getContent())
                         .targetDate(targetDateTime)
                         .build());
+
+        // 일정 등록여부 true로 변경
+        entry.updateScheduledTrue();
+
         return ScheduleResponse.from(schedule);
     }
 

--- a/src/main/java/ject/petfit/domain/slot/controller/SlotController.java
+++ b/src/main/java/ject/petfit/domain/slot/controller/SlotController.java
@@ -1,0 +1,83 @@
+package ject.petfit.domain.slot.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import ject.petfit.domain.slot.dto.request.SlotActivatedRequest;
+import ject.petfit.domain.slot.dto.request.SlotAmountRequest;
+import ject.petfit.domain.slot.dto.request.SlotInitializeRequest;
+import ject.petfit.domain.slot.dto.response.SlotActivatedResponse;
+import ject.petfit.domain.slot.dto.response.SlotAmountResponse;
+import ject.petfit.domain.slot.dto.response.SlotInitializeResponse;
+import ject.petfit.domain.slot.service.SlotService;
+import ject.petfit.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/slots")
+@Tag(name = "Slot", description = "슬롯 설정 API")
+public class SlotController {
+    private final SlotService slotService;
+
+    // 반려동물 슬롯 초기화 (회원가입 슬롯 설정)
+    @PostMapping("/{petId}/initialize")
+    @Operation(summary = "반려동물 슬롯 초기화", description = "회원가입 후 반려동물의 슬롯을 초기화합니다. <br>" +
+            "사료량, 음수량, 배변량은 미설정시 null 입력 <br>" +
+            "슬롯 6개 활성화 여부는 null 입력 불가")
+    public ResponseEntity<ApiResponse<SlotInitializeResponse>> initialize(
+            @PathVariable Long petId,
+            @RequestBody @Valid SlotInitializeRequest slotInitializeRequest
+            ) {
+
+        return ResponseEntity.status(201).body(ApiResponse.success(
+                slotService.initializePetSlot(petId, slotInitializeRequest))
+        );
+    }
+
+    // 슬롯 활성화 상태 조회
+    @GetMapping("/{petId}/activated")
+    @Operation(summary = "슬롯 활성화 상태 조회", description = "특정 반려동물의 슬롯 활성화 상태를 조회합니다.")
+    public ResponseEntity<ApiResponse<SlotActivatedResponse>> activated(
+            @PathVariable Long petId)
+    {
+        return ResponseEntity.ok(ApiResponse.success(slotService.getSlotActivated(petId)));
+    }
+
+    // 슬롯 활성화 상태 변경
+    @PatchMapping("/{petId}/activated")
+    @Operation(summary = "슬롯 활성화 상태 변경", description = "특정 반려동물의 슬롯 활성화 상태를 변경합니다. <br>" +
+            "수정 없는 슬롯은 null 입력 혹은 기존값 입력")
+    public ResponseEntity<ApiResponse<SlotActivatedResponse>> activated(
+            @PathVariable Long petId,
+            @RequestBody @Valid SlotActivatedRequest slotActivatedRequest
+    ){
+        return ResponseEntity.status(201).body(
+                ApiResponse.success(slotService.setSlotActivated(petId, slotActivatedRequest))
+        );
+    }
+
+    // 사료, 음수, 배변 목표량 조회
+    @GetMapping("/{petId}/amounts")
+    @Operation(summary = "사료, 음수, 배변 목표량 조회", description = "특정 반려동물의 사료, 음수, 배변 목표량을 조회합니다.")
+    public ResponseEntity<ApiResponse<SlotAmountResponse>> getAmounts(
+            @PathVariable Long petId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(slotService.getSlotAmounts(petId)));
+    }
+
+    // 사료, 음수, 배변 목표량 설정
+    @PatchMapping("/{petId}/amounts")
+    @Operation(summary = "사료, 음수, 배변 목표량 설정", description = "특정 반려동물의 사료, 음수, 배변 목표량을 설정합니다.<br>" +
+            "수정 없는 슬롯은 null 입력 혹은 기존값 입력")
+    public ResponseEntity<ApiResponse<SlotAmountResponse>> setAmounts(
+            @PathVariable Long petId,
+            @RequestBody @Valid SlotAmountRequest slotAmountRequest
+    ) {
+        return ResponseEntity.status(201).body(
+                ApiResponse.success(slotService.setSlotAmounts(petId, slotAmountRequest))
+        );
+    }
+}

--- a/src/main/java/ject/petfit/domain/slot/dto/request/SlotActivatedRequest.java
+++ b/src/main/java/ject/petfit/domain/slot/dto/request/SlotActivatedRequest.java
@@ -1,0 +1,28 @@
+package ject.petfit.domain.slot.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SlotActivatedRequest {
+    @Schema(description = "사료 슬롯 활성화 여부", example = "true")
+    private Boolean feedActivated;      // 사료 슬롯 활성화 여부
+
+    @Schema(description = "음수 슬롯 활성화 여부", example = "true")
+    private Boolean waterActivated;     // 음수 슬롯 활성화 여부
+
+    @Schema(description = "산책 슬롯 활성화 여부", example = "false")
+    private Boolean walkActivated;      // 산책 슬롯 활성화 여부
+
+    @Schema(description = "배변 슬롯 활성화 여부", example = "true")
+    private Boolean pottyActivated;     // 배변 슬롯 활성화 여부
+
+    @Schema(description = "치아 슬롯 활성화 여부", example = "false")
+    private Boolean dentalActivated;    // 치아 슬롯 활성화 여부
+
+    @Schema(description = "피부 슬롯 활성화 여부", example = "false")
+    private Boolean skinActivated;      // 피부 슬롯 활성화 여부
+
+}

--- a/src/main/java/ject/petfit/domain/slot/dto/request/SlotAmountRequest.java
+++ b/src/main/java/ject/petfit/domain/slot/dto/request/SlotAmountRequest.java
@@ -1,0 +1,22 @@
+package ject.petfit.domain.slot.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SlotAmountRequest {
+    @Schema(description = "사료 목표량", example = "150")
+    @Min(value = 0, message = "목표량은 0 이상이어야 합니다.")
+    private Integer feedAmount; // 사료 목표량
+
+    @Schema(description = "음수 목표량", example = "150")
+    @Min(value = 0, message = "목표량은 0 이상이어야 합니다.")
+    private Integer waterAmount; // 음수 목표량
+
+    @Schema(description = "산책 목표량", example = "150")
+    @Min(value = 0, message = "목표량은 0 이상이어야 합니다.")
+    private Integer walkAmount; // 산책 목표량
+}

--- a/src/main/java/ject/petfit/domain/slot/dto/request/SlotInitializeRequest.java
+++ b/src/main/java/ject/petfit/domain/slot/dto/request/SlotInitializeRequest.java
@@ -1,0 +1,36 @@
+package ject.petfit.domain.slot.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SlotInitializeRequest {
+    @Schema(description = "사료 슬롯 활성화 여부", defaultValue = "true")
+    private boolean feedActivated;      // 사료 슬롯 활성화 여부
+
+    @Schema(description = "음수 슬롯 활성화 여부", defaultValue = "true")
+    private boolean waterActivated;     // 음수 슬롯 활성화 여부
+
+    @Schema(description = "산책 슬롯 활성화 여부", defaultValue = "false")
+    private boolean walkActivated;      // 산책 슬롯 활성화 여부
+
+    @Schema(description = "배변 슬롯 활성화 여부", defaultValue = "true")
+    private boolean pottyActivated;     // 배변 슬롯 활성화 여부
+
+    @Schema(description = "치아 슬롯 활성화 여부", defaultValue = "false")
+    private boolean dentalActivated;    // 치아 슬롯 활성화 여부
+
+    @Schema(description = "피부 슬롯 활성화 여부", defaultValue = "false")
+    private boolean skinActivated;      // 피부 슬롯 활성화 여부
+
+    @Schema(description = "사료 목표량", example = "150")
+    private Integer feedAmount; // 사료 목표량
+
+    @Schema(description = "음수 목표량", example = "150")
+    private Integer waterAmount; // 음수 목표량
+
+    @Schema(description = "산책 목표량", example = "150")
+    private Integer walkAmount; // 산책 목표량
+}

--- a/src/main/java/ject/petfit/domain/slot/dto/response/SlotActivatedResponse.java
+++ b/src/main/java/ject/petfit/domain/slot/dto/response/SlotActivatedResponse.java
@@ -1,0 +1,34 @@
+package ject.petfit.domain.slot.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import ject.petfit.domain.slot.entity.Slot;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "슬롯 활성화 응답 DTO")
+public class SlotActivatedResponse {
+    private boolean feedActivated; // 사료 슬롯 활성화 여부
+    private boolean waterActivated; // 음수 슬롯 활성화 여부
+    private boolean walkActivated; // 산책 슬롯 활성화 여부
+    private boolean pottyActivated; // 배변 슬롯 활성화 여부
+    private boolean dentalActivated; // 치아 슬롯 활성화 여부
+    private boolean skinActivated; // 피부 슬롯 활성화 여부
+
+    public static SlotActivatedResponse from(Slot slot) {
+        return SlotActivatedResponse.builder()
+                .feedActivated(slot.isFeedActivated())
+                .waterActivated(slot.isWaterActivated())
+                .walkActivated(slot.isWalkActivated())
+                .pottyActivated(slot.isPottyActivated())
+                .dentalActivated(slot.isDentalActivated())
+                .skinActivated(slot.isSkinActivated())
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/slot/dto/response/SlotAmountResponse.java
+++ b/src/main/java/ject/petfit/domain/slot/dto/response/SlotAmountResponse.java
@@ -1,0 +1,27 @@
+package ject.petfit.domain.slot.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ject.petfit.domain.slot.entity.Slot;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "슬롯 목표량 응답 DTO")
+public class SlotAmountResponse {
+    private Integer feedAmount; // 사료 목표량
+    private Integer waterAmount; // 음수 목표량
+    private Integer walkAmount; // 산책 목표량
+
+    public static SlotAmountResponse from(Slot slot) {
+        return SlotAmountResponse.builder()
+                .feedAmount(slot.getFeedAmount())
+                .waterAmount(slot.getWaterAmount())
+                .walkAmount(slot.getWalkAmount())
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/slot/dto/response/SlotInitializeResponse.java
+++ b/src/main/java/ject/petfit/domain/slot/dto/response/SlotInitializeResponse.java
@@ -1,0 +1,36 @@
+package ject.petfit.domain.slot.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ject.petfit.domain.slot.entity.Slot;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "슬롯 초기화 응답 DTO")
+public class SlotInitializeResponse {
+    private boolean feedActivated;      // 사료 슬롯 활성화 여부
+    private boolean waterActivated;     // 음수 슬롯 활성화 여부
+    private boolean walkActivated;      // 산책 슬롯 활성화 여부
+    private boolean pottyActivated;     // 배변 슬롯 활성화 여부
+    private boolean dentalActivated;    // 치아 슬롯 활성화 여부
+    private boolean skinActivated;      // 피부 슬롯 활성화 여부
+    private Integer feedAmount;         // 사료 목표량
+    private Integer waterAmount;        // 음수 목표량
+    private Integer walkAmount;         // 산책 목표량
+
+    public static SlotInitializeResponse from(Slot slot){
+        return SlotInitializeResponse.builder()
+                .feedActivated(slot.isFeedActivated())
+                .waterActivated(slot.isWaterActivated())
+                .walkActivated(slot.isWalkActivated())
+                .pottyActivated(slot.isPottyActivated())
+                .dentalActivated(slot.isDentalActivated())
+                .skinActivated(slot.isSkinActivated())
+                .feedAmount(slot.getFeedAmount())
+                .waterAmount(slot.getWaterAmount())
+                .walkAmount(slot.getWalkAmount())
+                .build();
+    }
+}

--- a/src/main/java/ject/petfit/domain/slot/entity/Slot.java
+++ b/src/main/java/ject/petfit/domain/slot/entity/Slot.java
@@ -1,0 +1,77 @@
+package ject.petfit.domain.slot.entity;
+
+import jakarta.persistence.*;
+import ject.petfit.domain.slot.dto.request.SlotActivatedRequest;
+import ject.petfit.global.common.BaseTime;
+import lombok.*;
+import ject.petfit.domain.pet.entity.Pet;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Table(name = "slot")
+@Builder
+@AllArgsConstructor
+@ToString
+public class Slot {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long slotId;
+
+    @Column(nullable = false)
+    private boolean feedActivated;     // 사료 슬롯 활성화 여부
+
+    @Column(nullable = false)
+    private boolean waterActivated;    // 음수 슬롯 활성화 여부
+
+    @Column(nullable = false)
+    private boolean walkActivated;     // 산책 슬롯 활성화 여부
+
+    @Column(nullable = false)
+    private boolean pottyActivated;    // 배변 슬롯 활성화 여부
+
+    @Column(nullable = false)
+    private boolean dentalActivated;   // 치아 슬롯 활성화 여부
+
+    @Column(nullable = false)
+    private boolean skinActivated;     // 피부 슬롯 활성화 여부
+
+    private Integer feedAmount;        // 사료 목표량
+    private Integer waterAmount;       // 음수 목표량
+    private Integer walkAmount;        // 산책 목표량
+
+    @OneToOne
+    @JoinColumn(name = "pet_id")
+    private Pet pet;
+
+    public void updateFeedAmount(Integer amount) {
+        this.feedAmount = amount;
+    }
+    public void updateWaterAmount(Integer amount) {
+        this.waterAmount = amount;
+    }
+    public void updateWalkAmount(Integer amount) {
+        this.walkAmount = amount;
+    }
+
+    public void updateSlotActivated(SlotActivatedRequest request) {
+        if (request.getFeedActivated() != null) {
+            this.feedActivated = request.getFeedActivated();
+        }
+        if (request.getWaterActivated() != null) {
+            this.waterActivated = request.getWaterActivated();
+        }
+        if (request.getWalkActivated() != null) {
+            this.walkActivated = request.getWalkActivated();
+        }
+        if (request.getPottyActivated() != null) {
+            this.pottyActivated = request.getPottyActivated();
+        }
+        if (request.getDentalActivated() != null) {
+            this.dentalActivated = request.getDentalActivated();
+        }
+        if (request.getSkinActivated() != null) {
+            this.skinActivated = request.getSkinActivated();
+        }
+    }
+}

--- a/src/main/java/ject/petfit/domain/slot/exception/SlotErrorCode.java
+++ b/src/main/java/ject/petfit/domain/slot/exception/SlotErrorCode.java
@@ -1,0 +1,17 @@
+package ject.petfit.domain.slot.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SlotErrorCode {
+    SLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "SLOT-404", "해당 슬롯을 찾을 수 없습니다."),
+    TARGET_AMOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "TARGET-404", "해당 목표량을 찾을 수 없습니다."),
+    SLOT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SLOT-409", "해당 반려동물에 대한 슬롯이 이미 존재합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ject/petfit/domain/slot/exception/SlotException.java
+++ b/src/main/java/ject/petfit/domain/slot/exception/SlotException.java
@@ -1,0 +1,16 @@
+package ject.petfit.domain.slot.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class SlotException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String code;
+
+    public SlotException(SlotErrorCode slotErrorCode) {
+        super(slotErrorCode.getMessage());
+        this.httpStatus = slotErrorCode.getHttpStatus();
+        this.code = slotErrorCode.getCode();
+    }
+}

--- a/src/main/java/ject/petfit/domain/slot/repository/SlotRepository.java
+++ b/src/main/java/ject/petfit/domain/slot/repository/SlotRepository.java
@@ -1,0 +1,10 @@
+package ject.petfit.domain.slot.repository;
+
+import ject.petfit.domain.slot.entity.Slot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface SlotRepository extends JpaRepository<Slot, Long> {
+
+    boolean existsByPetId(Long petId);
+}

--- a/src/main/java/ject/petfit/domain/slot/service/SlotService.java
+++ b/src/main/java/ject/petfit/domain/slot/service/SlotService.java
@@ -1,0 +1,107 @@
+package ject.petfit.domain.slot.service;
+
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import ject.petfit.domain.pet.entity.Pet;
+import ject.petfit.domain.pet.exception.PetErrorCode;
+import ject.petfit.domain.pet.exception.PetException;
+import ject.petfit.domain.pet.repository.PetRepository;
+import ject.petfit.domain.slot.dto.request.SlotActivatedRequest;
+import ject.petfit.domain.slot.dto.request.SlotAmountRequest;
+import ject.petfit.domain.slot.dto.request.SlotInitializeRequest;
+import ject.petfit.domain.slot.dto.response.SlotActivatedResponse;
+import ject.petfit.domain.slot.dto.response.SlotAmountResponse;
+import ject.petfit.domain.slot.dto.response.SlotInitializeResponse;
+import ject.petfit.domain.slot.entity.Slot;
+import ject.petfit.domain.slot.exception.SlotErrorCode;
+import ject.petfit.domain.slot.exception.SlotException;
+import ject.petfit.domain.slot.repository.SlotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SlotService {
+    private final PetRepository petRepository;
+    private final SlotRepository slotRepository;
+
+    // 공통 메서드 - 특정 반려동물의 슬롯 조회
+    private Slot getSlotOrThrow(Long petId) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
+        Slot slot = pet.getSlot();
+        if (slot == null) {
+            throw new SlotException(SlotErrorCode.SLOT_NOT_FOUND);
+        }
+        return slot;
+    }
+
+    // 반려동물 슬롯 초기화 (회원가입 슬롯 설정)
+    @Transactional
+    public SlotInitializeResponse initializePetSlot(Long petId, SlotInitializeRequest request) {
+        // petId로 Pet 엔티티 조회
+        Pet pet = petRepository.findById(petId).orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
+
+        // 슬롯 레코드가 이미 존재하는지 확인
+        if (slotRepository.existsByPetId(petId)) {
+            throw new SlotException(SlotErrorCode.SLOT_ALREADY_EXISTS);
+        }
+
+        // 초기 슬롯 레코드 생성 및 저장
+        Slot slot = slotRepository.save(Slot.builder()
+                .feedActivated(request.isFeedActivated())
+                .waterActivated(request.isWaterActivated())
+                .walkActivated(request.isWalkActivated())
+                .pottyActivated(request.isPottyActivated())
+                .dentalActivated(request.isDentalActivated())
+                .skinActivated(request.isSkinActivated())
+                .feedAmount(request.getFeedAmount())
+                .waterAmount(request.getWaterAmount())
+                .walkAmount(request.getWalkAmount())
+                .pet(pet)
+                .build());
+        return SlotInitializeResponse.from(slot);
+    }
+
+
+    // 슬롯 활성화 상태 조회
+    public SlotActivatedResponse getSlotActivated(Long petId) {
+        Slot slot = getSlotOrThrow(petId);
+        return SlotActivatedResponse.from(slot);
+    }
+
+    // 슬롯 활성화 상태 설정
+    @Transactional
+    public SlotActivatedResponse setSlotActivated(Long petId, SlotActivatedRequest request) {
+        Slot slot = getSlotOrThrow(petId);
+        slot.updateSlotActivated(request);
+        slotRepository.save(slot);
+        return SlotActivatedResponse.from(slot);
+    }
+
+    // 사료, 음수, 배변 목표량 조회
+    public SlotAmountResponse getSlotAmounts(Long petId) {
+        Slot slot = getSlotOrThrow(petId);
+        return SlotAmountResponse.from(slot);
+    }
+
+    // 사료, 음수, 배변 목표량 설정
+    @Transactional
+    public SlotAmountResponse setSlotAmounts(Long petId, @Valid SlotAmountRequest request) {
+        Slot slot = getSlotOrThrow(petId);
+
+        // 사료, 음수, 산책 목표량 업데이트 (null 값은 수정하지 않음)
+        if (request.getFeedAmount() != null) {
+            slot.updateFeedAmount(request.getFeedAmount());
+        }
+        if (request.getWaterAmount() != null) {
+            slot.updateWaterAmount(request.getWaterAmount());
+        }
+        if (request.getWalkAmount() != null) {
+            slot.updateWalkAmount(request.getWalkAmount());
+        }
+
+        slotRepository.save(slot);
+        return SlotAmountResponse.from(slot);
+    }
+}

--- a/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
+++ b/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 @Slf4j
 @Configuration
@@ -50,7 +51,19 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/auth/**",
-                                "/error"
+                                "/error",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/health/**",
+
+                                // 개발용으로 허용
+                                "/api/routines/**",
+                                "/api/remarks/**",
+                                "/api/schedules/**",
+                                "/api/slots/**",
+                                "/api/entries/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/ject/petfit/global/exception/ErrorCode.java
+++ b/src/main/java/ject/petfit/global/exception/ErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     // 커스텀 처리할 오류
-    DEV_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAMPLE-404", "사용자를 찾을 수 없습니다(커스텀 예외 처리)");
+    DEV_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAMPLE-404", "사용자를 찾을 수 없습니다(커스텀 예외 처리)"),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "COMMON-400", "입력 날짜 형식이 맞지 않습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/ject/petfit/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ject/petfit/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package ject.petfit.global.exception;
 import ject.petfit.domain.entry.exception.EntryException;
 import ject.petfit.domain.pet.exception.PetException;
 import ject.petfit.domain.remark.exception.RemarkException;
+import ject.petfit.domain.routine.exception.RoutineException;
 import ject.petfit.domain.schedule.exception.ScheduleException;
+import ject.petfit.domain.slot.exception.SlotException;
 import ject.petfit.domain.user.exception.AuthUserException;
 import ject.petfit.domain.user.exception.InvalidGrantException;
 import ject.petfit.global.common.ApiResponse;
@@ -92,6 +94,26 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(EntryException.class)
     public ResponseEntity<ApiResponse<Void>> handleEntryException(EntryException e) {
+        log.info(e.getMessage(), e);
+        ApiResponse<Void> response = ApiResponse.fail(
+                e.getCode(),
+                e.getMessage()
+        );
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(SlotException.class)
+    public ResponseEntity<ApiResponse<Void>> handleSlotException(SlotException e) {
+        log.info(e.getMessage(), e);
+        ApiResponse<Void> response = ApiResponse.fail(
+                e.getCode(),
+                e.getMessage()
+        );
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(RoutineException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRoutineException(RoutineException e) {
         log.info(e.getMessage(), e);
         ApiResponse<Void> response = ApiResponse.fail(
                 e.getCode(),

--- a/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
@@ -36,8 +36,22 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         // 인증이 필요 없는 엔드포인트는 토큰 체크 건너뛰기
-        if (request.getRequestURI().startsWith("/auth/") ||
-                request.getRequestURI().equals("/error")) {
+        String uri = request.getRequestURI();
+        if (
+            uri.startsWith("/auth/") ||
+            uri.equals("/error") ||
+            uri.startsWith("/swagger-ui") ||
+            uri.startsWith("/v3/api-docs") ||
+            uri.startsWith("/swagger-resources") ||
+            uri.startsWith("/health") ||
+
+            // 개발용으로 허용
+            uri.startsWith("/api/routines/") ||
+            uri.startsWith("/api/remarks/") ||
+            uri.startsWith("/api/schedules/") ||
+            uri.startsWith("/api/slots/") ||
+            uri.startsWith("/api/entries/")
+        ) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     datasource:
         driver-class-name: org.postgresql.Driver
         url: jdbc:postgresql://localhost:5432/petfit
-        username: petfit
+        username: postgres
         password: ${DB_PASSWORD}
 
     jpa:
@@ -31,3 +31,4 @@ spring:
         secret: ${JWT_SECRET}
         access-token-time: 3600000  # 1 hour
         refresh-token-validity-seconds: 604800000  # 7 days
+


### PR DESCRIPTION
### 📖 개요
Slot, Entry, Routine API 구현
개발용으로 인증 및 토큰 검증 없이 API 요청 허용 설정

--------------

### ⚒️ 작업 내용
#### API  구현
Slot, Entry, Routine 도메인 관련 기능 구현

#### 설정 추가
개발용으로 다음 url을 인증과 토큰 검증 없이 허용(WebSecurityConfig, JwtAuthFilter)
- /swagger... 스웨거 관련 url
- /health/
- /api/routines/
- /api/remarks/
- /api/schedules/
- /api/slots/
- /api/entries/

---------------

### 📕 관련 이슈
 - issue #18 
 
---------------

### 특이사항
- 스웨거 로컬용 주소: http://localhost:8080/swagger-ui/index.html
- MVP 기간 API는 작업 완료, 이후 피드백 수정반영 있을때만 PR할듯