### PR TITLE
fix: 개발용으로 허용했던 엔드포인트 삭제

### DIFF
--- a/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
+++ b/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
@@ -64,13 +64,13 @@ public class WebSecurityConfig {
                                 "/health/**",
 
                                 // 개발용으로 허용
-                                "/api/pets/**",
-                                "/api/routines/**",
-                                "/api/remarks/**",
-                                "/api/schedules/**",
-                                "/api/slots/**",
-                                "/api/entries/**",
-                                "/api/members/**",
+//                                "/api/pets/**",
+//                                "/api/routines/**",
+//                                "/api/remarks/**",
+//                                "/api/schedules/**",
+//                                "/api/slots/**",
+//                                "/api/entries/**",
+//                                "/api/members/**",
 
                                 "/favicon.ico",
                                 "/static/**",

--- a/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
@@ -112,13 +112,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                uri.startsWith("/v3/api-docs") ||
                uri.startsWith("/swagger-resources") ||
                uri.startsWith("/health") ||
-               uri.startsWith("/api/routines") ||
-               uri.startsWith("/api/remarks") ||
-               uri.startsWith("/api/schedules") ||
-               uri.startsWith("/api/slots") ||
-               uri.startsWith("/api/entries") ||
-               uri.startsWith("/api/pets") ||
-               uri.startsWith("/api/members") ||
+//               uri.startsWith("/api/routines") ||
+//               uri.startsWith("/api/remarks") ||
+//               uri.startsWith("/api/schedules") ||
+//               uri.startsWith("/api/slots") ||
+//               uri.startsWith("/api/entries") ||
+//               uri.startsWith("/api/pets") ||
+//               uri.startsWith("/api/members") ||
                 uri.startsWith("/favicon.ico") ||
                 uri.startsWith("/favicon.png") ||
                 uri.startsWith("/static/") ||


### PR DESCRIPTION
### 📖 개요

개발용으로 허용했던 엔드포인트 삭제
-----------------------

⚒️ 작업 내용
- cors 설정 및 filter 엔드포인트 설정 비허용

------------------------

📕 관련 이슈
closed