### PR TITLE
fix: auth 엔드포인트 인증 강제 및 로그인/회원가입 인증 스킵

### DIFF
--- a/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
+++ b/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
@@ -55,7 +55,7 @@ public class WebSecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**",
+//                                "/api/auth/**",
                                 "/error",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
+++ b/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
@@ -56,6 +56,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
 //                                "/api/auth/**",
+                                "/api/auth/kakao/login/**",
                                 "/error",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
@@ -107,6 +107,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private boolean shouldSkipJwtCheck(String uri) {
         boolean result =
 //                uri.startsWith("/api/auth") ||
+                uri.startsWith("/api/auth/kakao/login") ||
                 uri.equals("/") ||
                uri.equals("/error") ||
                uri.startsWith("/swagger-ui") ||

--- a/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
@@ -105,7 +105,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     }
 
     private boolean shouldSkipJwtCheck(String uri) {
-        boolean result = uri.startsWith("/api/auth") ||
+        boolean result =
+//                uri.startsWith("/api/auth") ||
                 uri.equals("/") ||
                uri.equals("/error") ||
                uri.startsWith("/swagger-ui") ||


### PR DESCRIPTION
### 📖 개요

auth 엔드포인트 인증 강제 및 로그인/회원가입 인증 스킵
-----------------------

⚒️ 작업 내용
- /api/auth 하위 uri 중 로그인/회원가입을 제외한 나머지 엔드포인트 인증 강제 (Authorization 헤더 필요
------------------------

📕 관련 이슈
closed