### PR TITLE
refactor: 일간 루틴 조회 수정, 필터 허용

### DIFF
--- a/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
+++ b/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
@@ -20,14 +20,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/entries")
-@Tag(name = "Entry", description = "달력에서 기록 조회 API")
+@Tag(name = "Entry 수정중 - 루틴완료 로직 변경중, 일간 조회 추가예정", description = "달력에서 기록 조회 API")
 public class EntryController {
     private final EntryService entryService;
 
     // 월간 루틴체크,메모,특이사항,(일정) 유무 조회
     @GetMapping("/{petId}/monthly/{month}")
-    @Operation(summary = "월간 루틴체크, 메모, 특이사항, (일정) 유무 조회",
-            description = "특정 월의 루틴 체크, 메모, 특이사항, (일정) 유무를 조회 <br> " +
+    @Operation(summary = "월간 루틴체크,메모,특이사항,(일정) 유무 조회",
+            description = "특정 월의 루틴 완료, 메모, 특이사항, (일정) 유무를 조회 <br> " +
                     "요구사항은 아니지만 일정 유무도 응답에 포함함 ")
     public ResponseEntity<ApiResponse<List<EntryExistsResponse>>> getMonthlyEntries(
             @PathVariable Long petId,
@@ -39,10 +39,10 @@ public class EntryController {
         );
     }
 
-    // 주간 루틴, 특이사항 조회
+    // 주간 루틴 상태, 특이사항 조회
     @GetMapping("/{petId}/weekly/{week}")
-    @Operation(summary = "주간 루틴, 특이사항 조회",
-            description = "특정 주의 루틴 체크, 메모, 특이사항을 조회 <br> " +
+    @Operation(summary = "주간 루틴 상태, 특이사항 조회",
+            description = "특정 주의 루틴 완료, 메모, 특이사항을 조회 <br> " +
                     "해당 주의 루틴 체크, 메모, 특이사항을 모두 조회 <br> " +
                     "월간 조회처럼 유무 값도 포함 <br>" +
                     "주간 조회 응답에서 일간 조회 뽑아서 사용하면 API 요청을 줄일 수 있으니 일간 조회API를 따로 만들지 않았음")
@@ -55,6 +55,8 @@ public class EntryController {
                 ApiResponse.success(entryService.getWeeklyEntries(petId, week))
         );
     }
+
+    // 일간 루틴부터 만들어야함 -> 주간 루틴 반영
 
 }
 

--- a/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
+++ b/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/entries")
 @Tag(name = "Entry 수정중 - 루틴완료 로직 변경중, 일간 조회 추가예정", description = "달력에서 기록 조회 API")
-public class EntryController { //
+public class EntryController {
     private final EntryService entryService;
 
     // 월간 루틴체크,메모,특이사항,(일정) 유무 조회

--- a/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
+++ b/src/main/java/ject/petfit/domain/entry/controller/EntryController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/entries")
 @Tag(name = "Entry 수정중 - 루틴완료 로직 변경중, 일간 조회 추가예정", description = "달력에서 기록 조회 API")
-public class EntryController {
+public class EntryController { //
     private final EntryService entryService;
 
     // 월간 루틴체크,메모,특이사항,(일정) 유무 조회

--- a/src/main/java/ject/petfit/domain/entry/dto/EntryDailyResponse.java
+++ b/src/main/java/ject/petfit/domain/entry/dto/EntryDailyResponse.java
@@ -3,6 +3,7 @@ package ject.petfit.domain.entry.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import ject.petfit.domain.remark.dto.response.RemarkResponse;
+import ject.petfit.domain.routine.dto.response.DailyAllRoutineResponse;
 import ject.petfit.domain.routine.dto.response.RoutineResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,8 +36,10 @@ public class EntryDailyResponse {
     @Schema(description = "일정 존재 여부", example = "false")
     private boolean isScheduled; // 일정 존재 여부
 
-    List<RoutineResponse> routineResponseList;
     List<RemarkResponse> remarkResponseList;
+
+    List<RoutineResponse> routineResponseList; // 아래로 변경
+//    DailyAllRoutineResponse dailyAllRoutineResponse;
 
     public static EntryDailyResponse from(Entry entry) {
         return EntryDailyResponse.builder()

--- a/src/main/java/ject/petfit/domain/entry/service/EntryService.java
+++ b/src/main/java/ject/petfit/domain/entry/service/EntryService.java
@@ -89,6 +89,7 @@ public class EntryService {
         LocalDate endDate = startDate.plusDays(6);
         List<Entry> entries = entryRepository.findAllByPetAndEntryDateBetween(pet, startDate, endDate);
 
+
         return entries.stream()
                 .map(EntryDailyResponse::from)
                 .toList();

--- a/src/main/java/ject/petfit/domain/routine/controller/RoutineController.java
+++ b/src/main/java/ject/petfit/domain/routine/controller/RoutineController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import ject.petfit.domain.routine.dto.request.RoutineMemoRequest;
+import ject.petfit.domain.routine.dto.response.DailyAllRoutineResponse;
 import ject.petfit.domain.routine.dto.response.RoutineResponse;
 import ject.petfit.domain.routine.service.RoutineService;
 import ject.petfit.global.common.ApiResponse;
@@ -14,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,11 +23,13 @@ import java.util.List;
 public class RoutineController {
     private final RoutineService routineService;
 
-    // 루틴 조회 - 일간
+    // 일간 루틴 조회
     @GetMapping("/{petId}/daily/{date}")
-    @Operation(summary = "일간 루틴 조회", description = "특정 날짜의 일간 루틴들을 조회 <br> " +
-            "체크나 세모 등록된 값들만 응답" )
-    public ResponseEntity<ApiResponse<List<RoutineResponse>>> getDailyRoutines(
+    @Operation(summary = "일간 루틴 조회", description = "특정 날짜의 루틴들 상태 조회 <br> " +
+            "슬롯 활성화한 루틴들은 응답값 있음, 슬롯 비활성화 루틴은 null <br> " +
+            "슬롯 활성화환 루틴들의 상태는 CHECKED, MEMO, UNCHECKED 중 하나 <br> " +
+            "루틴 unchecked인 경우 routineId는 null" )
+    public ResponseEntity<ApiResponse<DailyAllRoutineResponse>> getDailyRoutines(
             @PathVariable Long petId,
             @Parameter(description = "yyyy-MM-dd 형식으로 입력", example = "2025-07-01")
             @PathVariable LocalDate date
@@ -37,9 +39,9 @@ public class RoutineController {
         );
     }
 
-    // 루틴 체크(V) 완료
+    // 루틴 체크(V)
     @PostMapping("/{petId}/{date}/{category}/check")
-    @Operation(summary = "루틴 체크 완료", description = "루틴을 체크 완료 상태로 변경")
+    @Operation(summary = "루틴 체크함", description = "루틴을 체크 상태로 변경")
     public ResponseEntity<ApiResponse<String>> checkRoutine(
             @PathVariable Long petId,
             @Parameter(description = "yyyy-MM-dd 형식으로 입력", example = "2025-07-01")

--- a/src/main/java/ject/petfit/domain/routine/dto/response/DailyAllRoutineResponse.java
+++ b/src/main/java/ject/petfit/domain/routine/dto/response/DailyAllRoutineResponse.java
@@ -1,0 +1,26 @@
+package ject.petfit.domain.routine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ject.petfit.domain.slot.entity.Slot;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "6개 모든 루틴 응답 DTO")
+public class DailyAllRoutineResponse {
+    private RoutineResponse feedRoutine;
+    private RoutineResponse waterRoutine;
+    private RoutineResponse walkRoutine;
+
+    private RoutineResponse pottyRoutine;
+    private RoutineResponse dentalRoutine;
+    private RoutineResponse skinRoutine;
+
+}

--- a/src/main/java/ject/petfit/domain/routine/dto/response/RoutineResponse.java
+++ b/src/main/java/ject/petfit/domain/routine/dto/response/RoutineResponse.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "루틴 응답 DTO")
+@Schema(description = "단일 루틴 응답 DTO")
 public class RoutineResponse {
     @Schema(description = "루틴 ID", example = "1")
     private Long routineId; // 루틴 ID

--- a/src/main/java/ject/petfit/domain/routine/enums/RoutineStatus.java
+++ b/src/main/java/ject/petfit/domain/routine/enums/RoutineStatus.java
@@ -2,7 +2,7 @@ package ject.petfit.domain.routine.enums;
 
 // ...existing code...
 public enum RoutineStatus {
-    CHECKED, MEMO
+    CHECKED, MEMO, UNCHECKED;
 }
 // ...existing code...
 

--- a/src/main/java/ject/petfit/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/ject/petfit/domain/routine/repository/RoutineRepository.java
@@ -5,6 +5,7 @@ import ject.petfit.domain.routine.entity.Routine;
 import ject.petfit.domain.routine.enums.RoutineStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/ject/petfit/domain/routine/service/RoutineService.java
+++ b/src/main/java/ject/petfit/domain/routine/service/RoutineService.java
@@ -9,6 +9,7 @@ import ject.petfit.domain.pet.exception.PetErrorCode;
 import ject.petfit.domain.pet.exception.PetException;
 import ject.petfit.domain.pet.repository.PetRepository;
 import ject.petfit.domain.routine.dto.request.RoutineMemoRequest;
+import ject.petfit.domain.routine.dto.response.DailyAllRoutineResponse;
 import ject.petfit.domain.routine.dto.response.RoutineResponse;
 import ject.petfit.domain.routine.entity.Routine;
 import ject.petfit.domain.routine.enums.RoutineStatus;
@@ -17,11 +18,15 @@ import ject.petfit.domain.routine.exception.RoutineException;
 import ject.petfit.domain.routine.repository.RoutineRepository;
 import ject.petfit.domain.slot.entity.Slot;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RoutineService {
@@ -56,27 +61,94 @@ public class RoutineService {
         }
     }
 
+    // 루틴 응답 생성
+    public RoutineResponse createRoutineResponse(Routine routine) {
+        return RoutineResponse.builder()
+                .routineId(routine.getRoutineId())
+                .category(routine.getCategory())
+                .status(routine.getStatus())
+                .targetAmount(routine.getTargetAmount())
+                .actualAmount(routine.getActualAmount())
+                .content(routine.getContent())
+                .date(routine.getEntry().getEntryDate())
+                .build();
+    }
+
+    // 루틴 unchecked 응답
+    public RoutineResponse uncheckedRoutineResponse(LocalDate date, String category, Integer targetAmount) {
+        return RoutineResponse.builder()
+                .routineId(null)
+                .category(category)
+                .status(RoutineStatus.UNCHECKED)
+                .targetAmount(targetAmount)
+                .actualAmount(0)
+                .content(null)
+                .date(date)
+                .build();
+    }
+
     // ------------------------------ API 메서드 -----------------------------------
 
-    // 루틴 조회 - 일간
-    public List<RoutineResponse> getDailyRoutines(Long petId, LocalDate entryDate) {
+    // 루틴 일간 조회
+    public DailyAllRoutineResponse getDailyRoutines(Long petId, LocalDate entryDate) {
 
         Pet pet = petRepository.findById(petId)
                 .orElseThrow(() -> new PetException(PetErrorCode.PET_NOT_FOUND));
 
-        // 해당 날짜의 entry 조회 - entry가 없으면 빈 리스트 반환
+        Slot slot = pet.getSlot();
+
+        // 슬롯 활성화되어 있으면 unchecked 루틴 생성, 슬롯 비활성화이면 null로 설정
+        RoutineResponse feedRoutine = slot.isFeedActivated()?
+                uncheckedRoutineResponse(entryDate, "feed", slot.getFeedAmount()) : null;
+        RoutineResponse waterRoutine = slot.isWaterActivated()?
+                uncheckedRoutineResponse(entryDate, "water", slot.getWaterAmount()) : null;
+        RoutineResponse walkRoutine = slot.isWalkActivated()?
+                uncheckedRoutineResponse(entryDate, "walk", slot.getWalkAmount()) : null;
+        RoutineResponse pottyRoutine = slot.isPottyActivated()?
+                uncheckedRoutineResponse(entryDate, "potty", null) : null;
+        RoutineResponse dentalRoutine = slot.isDentalActivated()?
+                uncheckedRoutineResponse(entryDate, "dental", null) : null;
+        RoutineResponse skinRoutine = slot.isSkinActivated()?
+                uncheckedRoutineResponse(entryDate, "skin", null) : null;
+
+        // 해당 날짜의 루틴이 하나라도 있는지 조회
+        // 기록이 없는 날이면 루틴 조회하지 않고 바로 반환
         Entry entry = entryRepository.findByPetAndEntryDate(pet, entryDate);
-        if (entry == null) {
-            return List.of(); 
+        if (entry == null || routineRepository.existsByEntry(entry)) {
+            return DailyAllRoutineResponse.builder()
+                    .feedRoutine(feedRoutine)
+                    .waterRoutine(waterRoutine)
+                    .walkRoutine(walkRoutine)
+                    .pottyRoutine(pottyRoutine)
+                    .dentalRoutine(dentalRoutine)
+                    .skinRoutine(skinRoutine)
+                    .build();
         }
 
-        // 루틴 조회
-        List<Routine> routines = routineRepository.findAllByEntry(entry);
+        // 기록이 있는 날이면 루틴 있는 경우에만 상태 세팅
+//        List<Routine> routines = routineRepository.findAllByEntry(entry);
+        List<Routine> routineList = entry.getRoutines();
 
-        // 루틴 응답으로 변환
-        return routines.stream()
-                .map(RoutineResponse::from)
-                .toList();
+        // 해당 날짜 저장된 루틴 있는 경우에는 상태 세팅
+        for (Routine routine : routineList) {
+            switch (routine.getCategory()) {
+                case "feed" -> feedRoutine = createRoutineResponse(routine);
+                case "water" -> waterRoutine = createRoutineResponse(routine);
+                case "walk" -> walkRoutine = createRoutineResponse(routine);
+                case "potty" -> pottyRoutine = createRoutineResponse(routine);
+                case "dental" -> dentalRoutine = createRoutineResponse(routine);
+                case "skin" -> skinRoutine = createRoutineResponse(routine);
+            }
+        }
+
+        return DailyAllRoutineResponse.builder()
+                .feedRoutine(feedRoutine)
+                .waterRoutine(waterRoutine)
+                .walkRoutine(walkRoutine)
+                .pottyRoutine(pottyRoutine)
+                .dentalRoutine(dentalRoutine)
+                .skinRoutine(skinRoutine)
+                .build();
     }
 
     // 루틴 체크(V) 완료
@@ -101,6 +173,7 @@ public class RoutineService {
                             .targetAmount(targetAmount)
                             .build();
                 });
+
         // 루틴 체크로 설정
         routine.updateStatus(RoutineStatus.CHECKED); // 상태를 체크로 변경
         routine.updateActualAmount(targetAmount); // 실제량을 목표량으로 설정

--- a/src/main/java/ject/petfit/domain/user/controller/KakaoAuthUserController.java
+++ b/src/main/java/ject/petfit/domain/user/controller/KakaoAuthUserController.java
@@ -46,7 +46,7 @@ public class KakaoAuthUserController {
     @Value("${spring.kakao.auth.admin}")
     private String adminKey;
 
-    @Value("${spring.kakao.redirect}")
+    @Value("ㅁㅇㄴㄹㅁㄴㅇㄹ")
     private String frontDomain;
 
 

--- a/src/main/java/ject/petfit/global/config/SwaggerConfig.java
+++ b/src/main/java/ject/petfit/global/config/SwaggerConfig.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Configuration;
         info = @Info(
                 title = "펫핏 API 명세서",
                 version = "v1",
-                description = "펫핏 API 명세서입니다"
+                description = "펫핏 API 명세서입니다 <br> " +
+                        "사용할 petId에 해당하는 슬롯 초기화(post /api/slots/{petId})를 반드시 실행하고 나머지 API를 진행해주세요"
         ),
         servers = {
 //                @Server(url = "배포할 도메인", description = "운영 서버"),

--- a/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
+++ b/src/main/java/ject/petfit/global/config/WebSecurityConfig.java
@@ -64,13 +64,13 @@ public class WebSecurityConfig {
                                 "/health/**",
 
                                 // 개발용으로 허용
-//                                "/api/pets/**",
-//                                "/api/routines/**",
-//                                "/api/remarks/**",
-//                                "/api/schedules/**",
-//                                "/api/slots/**",
-//                                "/api/entries/**",
-//                                "/api/members/**",
+                                "/api/pets/**",
+                                "/api/routines/**",
+                                "/api/remarks/**",
+                                "/api/schedules/**",
+                                "/api/slots/**",
+                                "/api/entries/**",
+                                "/api/members/**",
 
                                 "/favicon.ico",
                                 "/static/**",

--- a/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/ject/petfit/global/jwt/filter/JwtAuthFilter.java
@@ -113,13 +113,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                uri.startsWith("/v3/api-docs") ||
                uri.startsWith("/swagger-resources") ||
                uri.startsWith("/health") ||
-//               uri.startsWith("/api/routines") ||
-//               uri.startsWith("/api/remarks") ||
-//               uri.startsWith("/api/schedules") ||
-//               uri.startsWith("/api/slots") ||
-//               uri.startsWith("/api/entries") ||
-//               uri.startsWith("/api/pets") ||
-//               uri.startsWith("/api/members") ||
+               uri.startsWith("/api/routines") ||
+               uri.startsWith("/api/remarks") ||
+               uri.startsWith("/api/schedules") ||
+               uri.startsWith("/api/slots") ||
+               uri.startsWith("/api/entries") ||
+               uri.startsWith("/api/pets") ||
+               uri.startsWith("/api/members") ||
                 uri.startsWith("/favicon.ico") ||
                 uri.startsWith("/favicon.png") ||
                 uri.startsWith("/static/") ||


### PR DESCRIPTION
## 일간 루틴 조회 수정 @GetMapping("/{petId}/daily/{date}")
- 일간 루틴 조회에 6개 루틴 모두 응답으로 변경 (스웨거 참고)

## WebSecurtiyConfig, JwtFilter에서 API 허용
- 허용 안하면 현재는 스웨거에서 다른 API들 확인 못함 
- 테스트 토큰 발급 API를 추가해야 스웨거에서 가능

## 진행중
- Entry API는 수정중
- Entry에 일간 조회 추가 예정