### PR TITLE
fix: 토큰 쿼리 파라미터 적용 및 헤더 쿠키 적용

### DIFF
--- a/src/main/java/ject/petfit/domain/user/controller/KakaoAuthUserController.java
+++ b/src/main/java/ject/petfit/domain/user/controller/KakaoAuthUserController.java
@@ -21,6 +21,7 @@ import ject.petfit.global.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -53,7 +54,7 @@ public class KakaoAuthUserController {
 
     // 소셜 로그인/회원가입 -> 쿠키
     @GetMapping("/kakao/login")
-    public ResponseEntity<ApiResponse<AuthUserTokenResponseDto>> kakaoLogin(
+    public ResponseEntity<ApiResponse<Void>> kakaoLogin(
             @RequestParam("code") String accessCode, HttpServletResponse httpServletResponse) throws IOException {
         AuthUser user = authUserService.oAuthLogin(accessCode);
 
@@ -66,12 +67,16 @@ public class KakaoAuthUserController {
 //        httpServletResponse.addCookie(CookieUtils.addCookie("refresh_token", refreshToken.getToken()));
 
 //        httpServletResponse.sendRedirect(frontDomain);
-        httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.add(HttpHeaders.SET_COOKIE, CookieUtils.createTokenCookie("access_token", accessToken).toString());
+        headers.add(HttpHeaders.SET_COOKIE, CookieUtils.createTokenCookie("refresh_token", refreshToken.getToken()).toString());
 
-        AuthUserTokenResponseDto tokenResponseDto = new AuthUserTokenResponseDto(accessToken, refreshToken.getToken());
-
+//        AuthUserTokenResponseDto tokenResponseDto = new AuthUserTokenResponseDto(accessToken, refreshToken.getToken());
+//
+        httpServletResponse.sendRedirect(frontDomain +"token?access_token=" + accessToken + "&refresh_token=" + refreshToken.getToken());
         return ResponseEntity.status(HttpStatus.OK).body(
-                ApiResponse.success(tokenResponseDto)
+                ApiResponse.success(null)
         );
     }
 

--- a/src/main/java/ject/petfit/global/jwt/util/CookieUtils.java
+++ b/src/main/java/ject/petfit/global/jwt/util/CookieUtils.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 
@@ -18,6 +19,16 @@ public class CookieUtils {
         cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setMaxAge(7 * 24 * 60 * 60);
+        return cookie;
+    }
+
+    public static ResponseCookie createTokenCookie(String name, String value) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)
+                .build();
         return cookie;
     }
 


### PR DESCRIPTION
## 토큰 쿼리 파라미터 적용 및 헤더 쿠키 적용

### 쿼리 파라미터 적용
sendRedirect(frontDomain +"token?access_token=" + accessToken + "&refresh_token=" + refreshToken.getToken()); 
(frontDomain 값에 마지막에 / 있음)

### 헤더 쿠키 적용