### PR TITLE
feat: 토큰 쿠키 적용 api 및 신규유저 반환 api 구현

### DIFF
--- a/src/main/java/ject/petfit/domain/user/controller/KakaoAuthUserController.java
+++ b/src/main/java/ject/petfit/domain/user/controller/KakaoAuthUserController.java
@@ -165,7 +165,7 @@ public class KakaoAuthUserController {
 
     @PostMapping("/token/cookie")
     public ResponseEntity<ApiResponse<AuthUserIsNewResponseDto>> returnTokenCookie(
-            @RequestParam String accessToken, @RequestParam String refreshToken, HttpServletResponse response) {
+            @RequestParam String accessToken, @RequestParam String refreshToken) {
         AuthUserIsNewResponseDto isNewResponseDto = authUserService.isNewUserFromRefreshToken(refreshToken);
 
         // SameSite=None이 적용된 쿠키 생성

--- a/src/main/java/ject/petfit/domain/user/dto/response/AuthUserIsNewResponseDto.java
+++ b/src/main/java/ject/petfit/domain/user/dto/response/AuthUserIsNewResponseDto.java
@@ -1,0 +1,12 @@
+package ject.petfit.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthUserIsNewResponseDto {
+    private boolean isNewUser;
+}

--- a/src/main/java/ject/petfit/domain/user/service/AuthUserService.java
+++ b/src/main/java/ject/petfit/domain/user/service/AuthUserService.java
@@ -1,12 +1,15 @@
 package ject.petfit.domain.user.service;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
 import ject.petfit.domain.member.entity.Member;
 import ject.petfit.domain.member.entity.Role;
 import ject.petfit.domain.member.repository.MemberRepository;
+import ject.petfit.domain.pet.entity.Pet;
 import ject.petfit.domain.user.common.util.KakaoUtil;
 import ject.petfit.domain.user.converter.AuthUserConverter;
 import ject.petfit.domain.user.dto.KakaoDto;
+import ject.petfit.domain.user.dto.response.AuthUserIsNewResponseDto;
 import ject.petfit.domain.user.dto.response.AuthUserSimpleResponseDto;
 import ject.petfit.domain.user.entity.AuthUser;
 import ject.petfit.domain.user.exception.AuthUserErrorCode;
@@ -162,5 +165,18 @@ public class AuthUserService {
                 .nickname(authUser.getNickname())
                 .email(authUser.getEmail())
                 .build();
+    }
+
+    public AuthUserIsNewResponseDto isNewUserFromRefreshToken(String refreshToken) {
+        AuthUser authUser = refreshTokenRepository.findByToken(refreshToken)
+                .map(refreshTokenEntity -> refreshTokenEntity.getAuthUser())
+                .orElseThrow(() -> new AuthUserException(AuthUserErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        List<Pet> existingPets = authUser.getMember().getPets();
+        if (existingPets.isEmpty()) {
+            return new AuthUserIsNewResponseDto(false);
+        } else {
+            return new AuthUserIsNewResponseDto(true);
+        }
     }
 }

--- a/src/main/java/ject/petfit/global/jwt/util/CookieUtils.java
+++ b/src/main/java/ject/petfit/global/jwt/util/CookieUtils.java
@@ -46,11 +46,21 @@ public class CookieUtils {
         }
     }
 
+    public static Cookie createCookie(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setSecure(true);
+        cookie.setDomain(frontDomain);
+        cookie.setPath("/");
+        cookie.setMaxAge(7 * 24 * 60 * 60);
+        return cookie;
+    }
+
     public static ResponseCookie createTokenCookie(String name, String value) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
-                .httpOnly(true)
                 .secure(true)
+                .domain(frontDomain)
                 .path("/")
+                .sameSite("none")
                 .maxAge(7 * 24 * 60 * 60)
                 .build();
         return cookie;


### PR DESCRIPTION
/api/auth/token/cookie api를 이용하여
RequestParam으로 accessToken과 refreshToken을 받아 쿠키로 반환
동시에 동물이 등록된 여부로 새로 신규 유저를 판단하여 결과 isNewUser dto를 body에 전달